### PR TITLE
调整设置用户上下文的时机，不判断是否开启登录框，只要实现getUserByToken就写入用户上下文

### DIFF
--- a/magic-api/src/main/java/org/ssssssss/magicapi/core/interceptor/MagicWebRequestInterceptor.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/core/interceptor/MagicWebRequestInterceptor.java
@@ -19,36 +19,34 @@ import java.util.Optional;
  */
 public class MagicWebRequestInterceptor implements HandlerInterceptor {
 
-    private final MagicCorsFilter magicCorsFilter;
+	private final MagicCorsFilter magicCorsFilter;
 
-    private final AuthorizationInterceptor authorizationInterceptor;
+	private final AuthorizationInterceptor authorizationInterceptor;
 
-    public MagicWebRequestInterceptor(MagicCorsFilter magicCorsFilter, AuthorizationInterceptor authorizationInterceptor) {
-        this.magicCorsFilter = magicCorsFilter;
-        this.authorizationInterceptor = authorizationInterceptor;
-    }
+	public MagicWebRequestInterceptor(MagicCorsFilter magicCorsFilter, AuthorizationInterceptor authorizationInterceptor) {
+		this.magicCorsFilter = magicCorsFilter;
+		this.authorizationInterceptor = authorizationInterceptor;
+	}
 
-    @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws MagicLoginException {
-        HandlerMethod handlerMethod;
-        if (handler instanceof HandlerMethod) {
-            handlerMethod = (HandlerMethod) handler;
-            handler = handlerMethod.getBean();
-            if (handler instanceof MagicController) {
-                if (magicCorsFilter != null) {
-                    magicCorsFilter.process(request, response);
-                }
-                Valid valid = handlerMethod.getMethodAnnotation(Valid.class);
-                boolean validRequiredLogin = (valid == null || valid.requireLogin());
-                if (validRequiredLogin) {
-                    Optional.ofNullable(authorizationInterceptor.getUserByToken(
-                            request.getHeader(Constants.MAGIC_TOKEN_HEADER))).ifPresent(it ->
-                            request.setAttribute(Constants.ATTRIBUTE_MAGIC_USER, it)
-                    );
-                }
-                ((MagicController) handler).doValid(request, valid);
-            }
-        }
-        return true;
-    }
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws MagicLoginException {
+		HandlerMethod handlerMethod;
+		if (handler instanceof HandlerMethod) {
+			handlerMethod = (HandlerMethod) handler;
+			handler = handlerMethod.getBean();
+			if (handler instanceof MagicController) {
+				if (magicCorsFilter != null) {
+					magicCorsFilter.process(request, response);
+				}
+				Valid valid = handlerMethod.getMethodAnnotation(Valid.class);
+				boolean validRequiredLogin = (valid == null || valid.requireLogin());
+				if (validRequiredLogin) {
+                    Optional.ofNullable(authorizationInterceptor.getUserByToken(request.getHeader(Constants.MAGIC_TOKEN_HEADER)))
+                            .ifPresent(it -> request.setAttribute(Constants.ATTRIBUTE_MAGIC_USER, it));
+				}
+				((MagicController) handler).doValid(request, valid);
+			}
+		}
+		return true;
+	}
 }

--- a/magic-api/src/main/java/org/ssssssss/magicapi/core/interceptor/MagicWebRequestInterceptor.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/core/interceptor/MagicWebRequestInterceptor.java
@@ -10,6 +10,7 @@ import org.ssssssss.magicapi.core.exception.MagicLoginException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Optional;
 
 /**
  * /magic/web相关接口的拦截器
@@ -18,34 +19,36 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class MagicWebRequestInterceptor implements HandlerInterceptor {
 
-	private final MagicCorsFilter magicCorsFilter;
+    private final MagicCorsFilter magicCorsFilter;
 
-	private final AuthorizationInterceptor authorizationInterceptor;
+    private final AuthorizationInterceptor authorizationInterceptor;
 
-	public MagicWebRequestInterceptor(MagicCorsFilter magicCorsFilter, AuthorizationInterceptor authorizationInterceptor) {
-		this.magicCorsFilter = magicCorsFilter;
-		this.authorizationInterceptor = authorizationInterceptor;
-	}
+    public MagicWebRequestInterceptor(MagicCorsFilter magicCorsFilter, AuthorizationInterceptor authorizationInterceptor) {
+        this.magicCorsFilter = magicCorsFilter;
+        this.authorizationInterceptor = authorizationInterceptor;
+    }
 
-	@Override
-	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws MagicLoginException {
-		HandlerMethod handlerMethod;
-		if (handler instanceof HandlerMethod) {
-			handlerMethod = (HandlerMethod) handler;
-			handler = handlerMethod.getBean();
-			if (handler instanceof MagicController) {
-				if (magicCorsFilter != null) {
-					magicCorsFilter.process(request, response);
-				}
-				Valid valid = handlerMethod.getMethodAnnotation(Valid.class);
-				boolean requiredLogin = authorizationInterceptor.requireLogin();
-				boolean validRequiredLogin = (valid == null || valid.requireLogin());
-				if (requiredLogin && validRequiredLogin) {
-					request.setAttribute(Constants.ATTRIBUTE_MAGIC_USER, authorizationInterceptor.getUserByToken(request.getHeader(Constants.MAGIC_TOKEN_HEADER)));
-				}
-				((MagicController) handler).doValid(request, valid);
-			}
-		}
-		return true;
-	}
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws MagicLoginException {
+        HandlerMethod handlerMethod;
+        if (handler instanceof HandlerMethod) {
+            handlerMethod = (HandlerMethod) handler;
+            handler = handlerMethod.getBean();
+            if (handler instanceof MagicController) {
+                if (magicCorsFilter != null) {
+                    magicCorsFilter.process(request, response);
+                }
+                Valid valid = handlerMethod.getMethodAnnotation(Valid.class);
+                boolean validRequiredLogin = (valid == null || valid.requireLogin());
+                if (validRequiredLogin) {
+                    Optional.ofNullable(authorizationInterceptor.getUserByToken(
+                            request.getHeader(Constants.MAGIC_TOKEN_HEADER))).ifPresent(it ->
+                            request.setAttribute(Constants.ATTRIBUTE_MAGIC_USER, it)
+                    );
+                }
+                ((MagicController) handler).doValid(request, valid);
+            }
+        }
+        return true;
+    }
 }

--- a/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/DialectAdapter.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/DialectAdapter.java
@@ -28,6 +28,7 @@ public class DialectAdapter {
 		add(new SQLServerDialect());
 		add(new SQLServer2005Dialect());
 		add(new DmDialect());
+		add(new ImpalaDialect());
 		add(new KingbaseSQLDialect());
 	}
 

--- a/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/ImpalaDialect.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/ImpalaDialect.java
@@ -1,0 +1,22 @@
+package org.ssssssss.magicapi.modules.db.dialect;
+
+import org.ssssssss.magicapi.modules.db.BoundSql;
+
+/**
+ * @author YuePeng
+ * date 2022/4/22 00:10
+ */
+public class ImpalaDialect implements Dialect {
+
+    @Override
+    public boolean match(String jdbcUrl) {
+        return jdbcUrl.contains(":impala:");
+    }
+
+    @Override
+    public String getPageSql(String sql, BoundSql boundSql, long offset, long limit) {
+        boundSql.addParameter(offset);
+        boundSql.addParameter(limit);
+        return sql + " order by null limit ? offset ?";
+    }
+}

--- a/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/ImpalaDialect.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/modules/db/dialect/ImpalaDialect.java
@@ -15,8 +15,8 @@ public class ImpalaDialect implements Dialect {
 
     @Override
     public String getPageSql(String sql, BoundSql boundSql, long offset, long limit) {
-        boundSql.addParameter(offset);
         boundSql.addParameter(limit);
+        boundSql.addParameter(offset);
         return sql + " order by null limit ? offset ?";
     }
 }


### PR DESCRIPTION
原因：如果在requireLogin中塞入用户上下文，可能在webSocket某些场景下获取不到request导致request bound异常，而且使用起来也不够优雅

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/20358088/164502940-78002a64-27ae-4380-b6a0-ec19d236b3b7.png">
