### PR TITLE
支持 spring-boot 3.2 以上版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.parameters>true</maven.compiler.parameters>
     </properties>
 	<modules>
 		<module>magic-api</module>


### PR DESCRIPTION
修改编译配置 使得编译时把参数名编译进字节码里 