### PR TITLE
允许接口路径不配置，但校验接口及其父级分组路径不能都为空

### DIFF
--- a/magic-api/src/main/java/org/ssssssss/magicapi/core/service/MagicResourceService.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/core/service/MagicResourceService.java
@@ -1,5 +1,6 @@
 package org.ssssssss.magicapi.core.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.ssssssss.magicapi.core.resource.Resource;
 import org.ssssssss.magicapi.core.model.*;
 import org.ssssssss.magicapi.utils.PathUtils;
@@ -9,6 +10,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 资源存储服务
@@ -130,7 +133,10 @@ public interface MagicResourceService {
 		String fullName;
 		if(entity instanceof PathMagicEntity){
 			PathMagicEntity pme = (PathMagicEntity) entity;
-			fullName = String.format("/%s/%s(/%s/%s)", getGroupName(pme.getGroupId()), pme.getName(), getGroupPath(pme.getGroupId()), pme.getPath());
+			fullName = String.format("/%s/%s(/%s)", getGroupName(pme.getGroupId()), pme.getName(), Stream
+                            .of(getGroupPath(pme.getGroupId()), pme.getPath())
+                            .filter(StringUtils::isNotBlank)
+                            .collect(Collectors.joining("/")));
 		} else {
 			fullName = String.format("/%s/%s", getGroupName(entity.getGroupId()), entity.getName());
 		}

--- a/magic-api/src/main/java/org/ssssssss/magicapi/core/service/impl/DefaultMagicAPIService.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/core/service/impl/DefaultMagicAPIService.java
@@ -37,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @MagicModule("magic")
 public class DefaultMagicAPIService implements MagicAPIService, JsonCodeConstants {
@@ -78,7 +80,11 @@ public class DefaultMagicAPIService implements MagicAPIService, JsonCodeConstant
 		MagicScriptContext scriptContext = new MagicScriptContext();
 		String fullGroupName = resourceService.getGroupName(info.getGroupId());
 		String fullGroupPath = resourceService.getGroupPath(info.getGroupId());
-		String scriptName = PathUtils.replaceSlash(String.format("/%s/%s(/%s/%s)", fullGroupName, info.getName(), fullGroupPath, info.getPath()));
+        String scriptName = PathUtils.replaceSlash(
+                String.format("/%s/%s(/%s)", fullGroupName, info.getName(), Stream
+                        .of(fullGroupPath, info.getPath())
+                        .filter(StringUtils::isNotBlank)
+                        .collect(Collectors.joining("/"))));
 		scriptContext.setScriptName(scriptName);
 		scriptContext.putMapIntoContext(context);
 		if (requestEntity != null) {

--- a/magic-api/src/main/java/org/ssssssss/magicapi/core/service/impl/DefaultMagicResourceService.java
+++ b/magic-api/src/main/java/org/ssssssss/magicapi/core/service/impl/DefaultMagicResourceService.java
@@ -528,8 +528,9 @@ public class DefaultMagicResourceService implements MagicResourceService, JsonCo
 			}
 			// 路径检查
 			if (storage.requirePath()) {
-				notBlank(((PathMagicEntity) entity).getPath(), PATH_REQUIRED);
+                // FIXME
 				String newMappingKey = storage.buildKey(entity);
+                notBlank(newMappingKey, PATH_REQUIRED);
 				isTrue(pathCache.get(storage.folder()).entrySet().stream().noneMatch(entry -> entry.getValue().equals(newMappingKey) && !entry.getKey().equals(entity.getId())), PATH_CONFLICT);
 			}
 			storage.validate(entity);


### PR DESCRIPTION
当前版本受限于后端校验接口路径entity.path不能为空，导致形如以下路径结尾不带/的接口无法在分组下简化定义。
get /aaa/bbb
put /aaa/bbb
post /aaa/bbb
delete /aaa/bbb

本pr对校验规则进行调整，放开entity.path可以为空，但校验grouppath + entity.path不能都为空